### PR TITLE
More user feedback changes

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -88,19 +88,19 @@ Next you can use the ``configure-tables`` command categorize each of your source
 * ``ignore`` for tables that should not be present in the destination database
 * ``empty`` for tables that should contain no data, but be present (also for tables that should be populated entirely from stories, see later)
 * ``vocabulary`` for tables that should be reproduced exactly in the destination database
-* ``normal`` for everything else
+* ``generate`` for everything else
 
 This command will start an interactive command shell. Don't be intimidated, just type ``?`` (and press return) to get help:
 
 .. code-block:: console
 
    $ sqlsynthgen configure-tables
-   Interactive table configuration (ignore, vocabulary, private, normal or empty). Type ? for help.
+   Interactive table configuration (ignore, vocabulary, private, generate or empty). Type ? for help.
 
    (table: myfirsttable) ?
 
    Use the commands 'ignore', 'vocabulary',
-   'private', 'empty' or 'normal' to set the table's type. Use 'next' or
+   'private', 'empty' or 'generate' to set the table's type. Use 'next' or
    'previous' to change table. Use 'tables' and 'columns' for
    information about the database. Use 'data', 'peek', 'select' or
    'count' to see some data contained in the current table. Use 'quit'
@@ -108,7 +108,7 @@ This command will start an interactive command shell. Don't be intimidated, just
    Documented commands (type help <topic>):
    ========================================
    columns  data   help    next    peek      private  select  vocabulary
-   counts   empty  ignore  normal  previous  quit     tables
+   counts   empty  ignore  generate  previous  quit     tables
 
    (table: myfirsttable) 
 
@@ -147,7 +147,7 @@ You can use ``tables`` to list all the tables and any configuration you have alr
 Setting the type of the table
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Use ``private``, ``ignore``, ``empty``, ``vocabulary`` or ``normal`` to set the type of the table. Any you don't set will be ``normal``.
+Use ``private``, ``ignore``, ``empty``, ``vocabulary`` or ``generate`` to set the type of the table. Any you don't set will be ``generate``.
 If you have previously run ``configure-tables`` (or edited the ``config.yaml`` file yourself!) the previously set types will be preserved unless you change them.
 
 Examining the data
@@ -181,7 +181,7 @@ You must type one of these three options in full but tab completion is available
 Configuring column generators
 -----------------------------
 
-The ``configure-generators`` command is similar to ``configure-tables``, but here you are configuring each column in ``normal`` and  ``private`` tables.
+The ``configure-generators`` command is similar to ``configure-tables``, but here you are configuring each column in ``generate`` and  ``private`` tables.
 
 The ``next``, ``previous``, ``peek``, ``columns``, ``select``, ``tables``, ``counts``, ``help`` and ``quit`` work as before, but ``next`` allows you to visit not just a different table but also any column with the ``next table.column`` syntax.
 

--- a/sqlsynthgen/dump.py
+++ b/sqlsynthgen/dump.py
@@ -1,0 +1,36 @@
+import csv
+import io
+import sqlalchemy
+from sqlalchemy.schema import MetaData
+
+from sqlsynthgen.settings import get_settings
+from sqlsynthgen.utils import (
+    create_db_engine,
+    get_sync_engine,
+    logger,
+)
+
+
+def _make_csv_writer(file):
+    return csv.writer(file, quoting=csv.QUOTE_MINIMAL)
+
+
+def dump_db_tables(
+        metadata: MetaData,
+        dsn: str,
+        schema: str | None,
+        table_name: str,
+        file: io.TextIOBase
+) -> None:
+    """ Output the table as CSV. """
+    if table_name not in  metadata.tables:
+        logger.error("%s is not a table described in the ORM file", table_name)
+        return
+    table = metadata.tables[table_name]
+    csv_out = _make_csv_writer(file)
+    csv_out.writerow(table.columns.keys())
+    engine = get_sync_engine(create_db_engine(dsn, schema_name=schema))
+    with engine.connect() as connection:
+        result = connection.execute(sqlalchemy.select(table))
+        for row in result:
+            csv_out.writerow(row.tuple())

--- a/sqlsynthgen/generators.py
+++ b/sqlsynthgen/generators.py
@@ -9,7 +9,6 @@ import logging
 import math
 import mimesis
 import mimesis.locales
-import psycopg2
 import re
 import sqlalchemy
 from sqlalchemy import Column, Engine, text

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -1,0 +1,27 @@
+"""Tests for the base module."""
+from sqlalchemy.schema import MetaData
+from tests.utils import RequiresDBTestCase
+from unittest.mock import MagicMock, call, patch
+
+from sqlsynthgen.dump import dump_db_tables
+
+class DumpTests(RequiresDBTestCase):
+    """Testing configure-tables."""
+    dump_file_path = "instrument.sql"
+    database_name = "instrument"
+    schema_name = "public"
+
+    @patch("sqlsynthgen.dump._make_csv_writer")
+    def test_dump_data(self, make_csv_writer: MagicMock) -> None:
+        """ Test dump-data. """
+        TEST_OUTPUT_FILE = "test_output_file_object"
+        metadata = MetaData()
+        metadata.reflect(self.engine)
+        dump_db_tables(metadata, self.dsn, self.schema_name, "player", TEST_OUTPUT_FILE)
+        make_csv_writer.assert_called_once_with(TEST_OUTPUT_FILE)
+        make_csv_writer.assert_has_calls([
+            call().writerow(["id", "given_name", "family_name"]),
+            call().writerow((1, 'Mark', 'Samson')),
+            call().writerow((2, 'Tim', 'Friedman')),
+            call().writerow((3, 'Pierre', 'Marchmont')),
+        ])


### PR DESCRIPTION
Fixes #31 sanity checking when setting table types. This also fixes #30 well enough.
Fixes #33, Fixes #34 didn't we already merge these?
Fixes #38 dump-data command outputs table to .csv file (or stdout)
Avoids attempting to create schema. This means that someone for whom a schema has been created can use this schema even if they don't have create-schema privileges.