### PR TITLE
configure-generators gains "set generator.name"

### DIFF
--- a/datafaker/main.py
+++ b/datafaker/main.py
@@ -380,6 +380,7 @@ def configure_missing(
 def configure_generators(
     config_file: Optional[str] = Option(CONFIG_FILENAME, help="Path of the configuration file to alter"),
     orm_file: str = Option(ORM_FILENAME, help="The name of the ORM yaml file"),
+    spec: Path = Option(None, help="CSV file (headerless) with fields table-name, column-name, generator-name to set non-interactively")
 ):
     """
     Interactively set generators for column data.
@@ -392,7 +393,7 @@ def configure_generators(
     if config_file_path.exists():
         config = yaml.load(config_file_path.read_text(encoding="UTF-8"), Loader=yaml.SafeLoader)
     metadata = load_metadata(orm_file, config)
-    config_updated = update_config_generators(src_dsn, settings.src_schema, metadata, config)
+    config_updated = update_config_generators(src_dsn, settings.src_schema, metadata, config, spec_path=spec)
     if config_updated is None:
         logger.debug("Cancelled")
         return

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -438,6 +438,25 @@ class ConfigureGeneratorsTests(RequiresDBTestCase):
                 f"SELECT AVG({COLUMN}) AS mean__{COLUMN}, STDDEV({COLUMN}) AS stddev__{COLUMN} FROM {TABLE}",
             )
 
+    def test_set_generator_distribution_directly(self):
+        """ Test that we can set one generator to gaussian without going through propose. """
+        with self._get_cmd({}) as gc:
+            TABLE = "string"
+            COLUMN = "frequency"
+            GENERATOR = "dist_gen.normal"
+            gc.do_next(f"{TABLE}.{COLUMN}")
+            gc.reset()
+            gc.do_set(GENERATOR)
+            self.assertListEqual(gc.messages, [])
+            gc.do_quit("")
+            self.assertEqual(len(gc.config["src-stats"]), 1)
+            self.assertSetEqual(set(gc.config["src-stats"][0].keys()), {"comments", "name", "query"})
+            self.assertEqual(gc.config["src-stats"][0]["name"], f"auto__{TABLE}")
+            self.assertEqual(
+                gc.config["src-stats"][0]["query"],
+                f"SELECT AVG({COLUMN}) AS mean__{COLUMN}, STDDEV({COLUMN}) AS stddev__{COLUMN} FROM {TABLE}",
+            )
+
     def test_set_generator_choice(self):
         """ Test that we can set one generator to uniform choice. """
         with self._get_cmd({}) as gc:


### PR DESCRIPTION
and --spec=table-column-gen.csv
Fixes #35, but not in a particularly good way.
Fixes #50, reasonably.