### PR TITLE
Fixed dist_gen.zipf_choice sampled ordering

### DIFF
--- a/datafaker/generators.py
+++ b/datafaker/generators.py
@@ -667,20 +667,20 @@ class ChoiceGenerator(Generator):
         self._fit = fit_from_buckets(counts, estimated_counts)
         if suppress_count == 0:
             if sample_count is None:
-                self._query = f"SELECT {column_name} AS value FROM {table_name} GROUP BY value ORDER BY COUNT({column_name}) DESC"
+                self._query = f"SELECT {column_name} AS value FROM {table_name} WHERE {column_name} IS NOT NULL GROUP BY value ORDER BY COUNT({column_name}) DESC"
                 self._comment = f"All the values that appear in column {column_name} of table {table_name}"
                 self._annotation = None
             else:
-                self._query = f"SELECT value FROM (SELECT {column_name} AS value FROM {table_name} ORDER BY RANDOM() LIMIT {sample_count}) AS _inner GROUP BY value"
+                self._query = f"SELECT value FROM (SELECT {column_name} AS value FROM {table_name} WHERE {column_name} IS NOT NULL ORDER BY RANDOM() LIMIT {sample_count}) AS _inner GROUP BY value ORDER BY COUNT(value) DESC"
                 self._comment = f"The values that appear in column {column_name} of a random sample of {sample_count} rows of table {table_name}"
                 self._annotation = "sampled"
         else:
             if sample_count is None:
-                self._query = f"SELECT value FROM (SELECT {column_name} AS value, COUNT({column_name}) AS count FROM {table_name} GROUP BY value) AS _inner WHERE {suppress_count} < count"
+                self._query = f"SELECT value FROM (SELECT {column_name} AS value, COUNT({column_name}) AS count FROM {table_name} WHERE {column_name} IS NOT NULL GROUP BY value ORDER BY count DESC) AS _inner WHERE {suppress_count} < count"
                 self._comment = f"All the values that appear in column {column_name} of table {table_name} more than {suppress_count} times"
                 self._annotation = "suppressed"
             else:
-                self._query = f"SELECT value FROM (SELECT value, COUNT(value) AS count FROM (SELECT {column_name} AS value FROM {table_name} ORDER BY RANDOM() LIMIT {sample_count}) AS _inner GROUP BY value) AS _inner WHERE {suppress_count} < count"
+                self._query = f"SELECT value FROM (SELECT value, COUNT(value) AS count FROM (SELECT {column_name} AS value FROM {table_name} WHERE {column_name} IS NOT NULL ORDER BY RANDOM() LIMIT {sample_count}) AS _inner GROUP BY value ORDER BY count DESC) AS _inner WHERE {suppress_count} < count"
                 self._comment = f"The values that appear more than {suppress_count} times in column {column_name}, out of a random sample of {sample_count} rows of table {table_name}"
                 self._annotation = "sampled and suppressed"
     def nominal_kwargs(self):

--- a/tests/examples/instrument.sql
+++ b/tests/examples/instrument.sql
@@ -99,3 +99,7 @@ INSERT INTO public.signature_model VALUES (3, 'Veleno', 2, 2);
 INSERT INTO public.signature_model VALUES (4, 'Grifter', NULL, NULL);
 INSERT INTO public.signature_model VALUES (5, 'Proton', 3, 1);
 INSERT INTO public.signature_model VALUES (6, 'Isabelle', NULL, 3);
+INSERT INTO public.signature_model VALUES (7, 'Natalia', NULL, 1);
+INSERT INTO public.signature_model VALUES (8, 'Ray', 2, NULL);
+INSERT INTO public.signature_model VALUES (9, 'DamageControl', 2, 3);
+INSERT INTO public.signature_model VALUES (10, 'Lucy', 3, 1);

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -177,6 +177,7 @@ class GeneratesDBTestCase(RequiresDBTestCase):
         (self.stats_fd, self.stats_file_path) = mkstemp(".yaml", "src_stats_", text=True)
         with os.fdopen(self.stats_fd, "w", encoding="utf-8") as stats_fh:
             stats_fh.write(yaml.dump(src_stats))
+        return src_stats
 
     def create_generators(self, config) -> None:
         """ ``create-generators`` with ``src-stats.yaml`` and the rest, producing ``df.py`` """


### PR DESCRIPTION
`dist_gen.zipf_choice` did not have the correct frequency ordering in the sampled/suppressed versions of the generators.
This fixes that, as well as removing NULLs from the choice operators (use missingness for that)