### PR TITLE
Multi column

### DIFF
--- a/datafaker/base.py
+++ b/datafaker/base.py
@@ -49,6 +49,9 @@ class DistributionGenerator:
     def normal(self, mean, sd) -> float:
         return random.normalvariate(float(mean), float(sd))
 
+    def lognormal(self, logmean, logsd) -> float:
+        return random.lognormvariate(float(logmean), float(logsd))
+
     def choice(self, a):
         c = random.choice(a)
         return c["value"] if type(c) is dict and "value" in c else c
@@ -62,17 +65,7 @@ class DistributionGenerator:
     def constant(self, value):
         return value
 
-    def multivariate_normal(self, cov):
-        """
-        Produce a list of values pulled from a multivariate distribution.
-
-        :param cov: A dict with various keys: ``rank`` is the number of
-        output values, ``m0``, ``m1``, ... are the means of the
-        distributions (``rank`` of them). ``c0_0``, ``c0_1``, ``c1_1``, ...
-        are the covariates, ``cN_M`` is the covariate of the ``N``th and
-        ``M``th varaibles, with 0 <= ``N`` <= ``M`` < ``rank``.
-        :return: list of ``rank`` floating point values
-        """
+    def multivariate_normal_np(self, cov):
         rank = int(cov["rank"])
         mean = [
             float(cov[f"m{i}"])
@@ -85,8 +78,34 @@ class DistributionGenerator:
             ]
             for j in range(rank)
         ]
-        out = self.np_gen.multivariate_normal(mean, covs)
-        return out.tolist()
+        return self.np_gen.multivariate_normal(mean, covs)
+
+    def multivariate_normal(self, cov):
+        """
+        Produce a list of values pulled from a multivariate distribution.
+
+        :param cov: A dict with various keys: ``rank`` is the number of
+        output values, ``m0``, ``m1``, ... are the means of the
+        distributions (``rank`` of them). ``c0_0``, ``c0_1``, ``c1_1``, ...
+        are the covariates, ``cN_M`` is the covariate of the ``N``th and
+        ``M``th varaibles, with 0 <= ``N`` <= ``M`` < ``rank``.
+        :return: list of ``rank`` floating point values
+        """
+        return self.multivariate_normal_np(cov).tolist()
+
+    def multivariate_lognormal(self, cov):
+        """
+        Produce a list of values pulled from a multivariate distribution.
+
+        :param cov: A dict with various keys: ``rank`` is the number of
+        output values, ``m0``, ``m1``, ... are the means of the
+        distributions (``rank`` of them). ``c0_0``, ``c0_1``, ``c1_1``, ...
+        are the covariates, ``cN_M`` is the covariate of the ``N``th and
+        ``M``th varaibles, with 0 <= ``N`` <= ``M`` < ``rank``. These
+        are all the means and covariants of the logs of the data.
+        :return: list of ``rank`` floating point values
+        """
+        return np.exp(self.multivariate_normal_np(cov)).tolist()
 
 
 class TableGenerator(ABC):

--- a/datafaker/base.py
+++ b/datafaker/base.py
@@ -65,7 +65,7 @@ class DistributionGenerator:
     def weighted_choice(self, a: list[dict[str, any]]) -> list[any]:
         """
         Choice weighted by the count in the original dataset.
-        :param a: a list of dicts, each with a ``v`` key
+        :param a: a list of dicts, each with a ``value`` key
         holding the value to be returned and a ``count`` key holding the
         number of that value found in the original dataset
         """
@@ -75,7 +75,7 @@ class DistributionGenerator:
             count = vc.get("count", 0)
             if count:
                 counts.append(count)
-                vs.append(vc.get("v", None))
+                vs.append(vc.get("value", None))
         c = random.choices(vs, weights=counts)[0]
         return c
 

--- a/datafaker/base.py
+++ b/datafaker/base.py
@@ -62,6 +62,23 @@ class DistributionGenerator:
         c = random.choices(a, weights=zipf_weights(n))[0]
         return c["value"] if type(c) is dict and "value" in c else c
 
+    def weighted_choice(self, a: list[dict[str, any]]) -> list[any]:
+        """
+        Choice weighted by the count in the original dataset.
+        :param a: a list of dicts, each with a ``v`` key
+        holding the value to be returned and a ``count`` key holding the
+        number of that value found in the original dataset
+        """
+        vs = []
+        counts = []
+        for vc in a:
+            count = vc.get("count", 0)
+            if count:
+                counts.append(count)
+                vs.append(vc.get("v", None))
+        c = random.choices(vs, weights=counts)[0]
+        return c
+
     def constant(self, value):
         return value
 

--- a/datafaker/generators.py
+++ b/datafaker/generators.py
@@ -916,7 +916,7 @@ class ChoiceGeneratorFactory(GeneratorFactory):
                         if type(v) is decimal.Decimal:
                             v = float(v)
                         values.append(v)
-                        cvs.append({"v": v, "count": c})
+                        cvs.append({"value": v, "count": c})
                 if counts:
                     generators += [
                         ZipfChoiceGenerator(table_name, column_name, values, counts),

--- a/datafaker/generators.py
+++ b/datafaker/generators.py
@@ -972,7 +972,8 @@ class MultivariateNormalGeneratorFactory(GeneratorFactory):
             return []
         # All columns must be numeric
         for c in columns:
-            if not isinstance(get_column_type(c), Numeric):
+            ct = get_column_type(c)
+            if not isinstance(ct, Numeric) and not isinstance(ct, Integer):
                 return []
         column_names = [c.name for c in columns]
         table = columns[0].table.name

--- a/datafaker/generators.py
+++ b/datafaker/generators.py
@@ -737,7 +737,7 @@ class ContinuousLogDistributionGeneratorFactory(ContinuousDistributionGeneratorF
                 ))
             ).first()
             if result is None or result.logstddev is None:
-                return None
+                return []
         return [
             LogNormalGenerator(
                 table_name,
@@ -1126,9 +1126,13 @@ class MultivariateNormalGeneratorFactory(GeneratorFactory):
         table = columns[0].table.name
         query = self.query(table, column_names)
         with engine.connect() as connection:
-            covariates = connection.execute(text(
-                query
-            )).mappings().first()
+            try:
+                covariates = connection.execute(text(
+                    query
+                )).mappings().first()
+            except Exception as e:
+                logger.debug("SQL query %s failed with error %s", query, e)
+                return []
             if not covariates or covariates["c0_0"] is None:
                 return []
             return [MultivariateNormalGenerator(

--- a/datafaker/generators.py
+++ b/datafaker/generators.py
@@ -216,7 +216,7 @@ class GeneratorFactory(ABC):
     A factory for making generators appropriate for a database column.
    """
     @abstractmethod
-    def get_generators(self, column: Column, engine: Engine) -> list[Generator]:
+    def get_generators(self, columns: list[Column], engine: Engine) -> list[Generator]:
         """
         Returns all the generators that might be appropriate for this column.
         """
@@ -295,11 +295,11 @@ class MultiGeneratorFactory(GeneratorFactory):
         super().__init__()
         self.factories = factories
 
-    def get_generators(self, column: Column, engine: Engine) -> list[Generator]:
+    def get_generators(self, columns: list[Column], engine: Engine) -> list[Generator]:
         return [
             generator
             for factory in self.factories
-            for generator in factory.get_generators(column, engine)
+            for generator in factory.get_generators(columns, engine)
         ]
 
 
@@ -444,7 +444,10 @@ class MimesisStringGeneratorFactory(GeneratorFactory):
     """
     All Mimesis generators that return strings.
     """
-    def get_generators(self, column: Column, engine: Engine):
+    def get_generators(self, columns: list[Column], engine: Engine):
+        if len(columns) != 1:
+            return []
+        column = columns[0]
         if not isinstance(get_column_type(column), String):
             return []
         try:
@@ -499,7 +502,10 @@ class MimesisFloatGeneratorFactory(GeneratorFactory):
     """
     All Mimesis generators that return floating point numbers.
     """
-    def get_generators(self, column: Column, _engine: Engine):
+    def get_generators(self, columns: list[Column], engine: Engine):
+        if len(columns) != 1:
+            return []
+        column = columns[0]
         if not isinstance(get_column_type(column), Numeric):
             return []
         return list(map(MimesisGenerator, [
@@ -511,7 +517,10 @@ class MimesisDateGeneratorFactory(GeneratorFactory):
     """
     All Mimesis generators that return dates.
     """
-    def get_generators(self, column: Column, engine: Engine):
+    def get_generators(self, columns: list[Column], engine: Engine):
+        if len(columns) != 1:
+            return []
+        column = columns[0]
         ct = get_column_type(column)
         if not isinstance(ct, Date):
             return []
@@ -522,7 +531,10 @@ class MimesisDateTimeGeneratorFactory(GeneratorFactory):
     """
     All Mimesis generators that return datetimes.
     """
-    def get_generators(self, column: Column, engine: Engine):
+    def get_generators(self, columns: list[Column], engine: Engine):
+        if len(columns) != 1:
+            return []
+        column = columns[0]
         ct = get_column_type(column)
         if not isinstance(ct, DateTime):
             return []
@@ -533,7 +545,10 @@ class MimesisTimeGeneratorFactory(GeneratorFactory):
     """
     All Mimesis generators that return times.
     """
-    def get_generators(self, column: Column, _engine: Engine):
+    def get_generators(self, columns: list[Column], engine: Engine):
+        if len(columns) != 1:
+            return []
+        column = columns[0]
         ct = get_column_type(column)
         if not isinstance(ct, Time):
             return []
@@ -544,7 +559,10 @@ class MimesisIntegerGeneratorFactory(GeneratorFactory):
     """
     All Mimesis generators that return integers.
     """
-    def get_generators(self, column: Column, _engine: Engine):
+    def get_generators(self, columns: list[Column], engine: Engine):
+        if len(columns) != 1:
+            return []
+        column = columns[0]
         ct = get_column_type(column)
         if not isinstance(ct, Numeric) and not isinstance(ct, Integer):
             return []
@@ -620,7 +638,10 @@ class ContinuousDistributionGeneratorFactory(GeneratorFactory):
     """
     All generators that want an average and standard deviation.
     """
-    def get_generators(self, column: Column, engine: Engine):
+    def get_generators(self, columns: list[Column], engine: Engine):
+        if len(columns) != 1:
+            return []
+        column = columns[0]
         ct = get_column_type(column)
         if not isinstance(ct, Numeric) and not isinstance(ct, Integer):
             return []
@@ -747,7 +768,10 @@ class ChoiceGeneratorFactory(GeneratorFactory):
     """
     SAMPLE_COUNT = MAXIMUM_CHOICES
     SUPPRESS_COUNT = 5
-    def get_generators(self, column: Column, engine: Engine):
+    def get_generators(self, columns: list[Column], engine: Engine):
+        if len(columns) != 1:
+            return []
+        column = columns[0]
         column_name = column.name
         table_name = column.table.name
         generators = []
@@ -847,7 +871,10 @@ class ConstantGeneratorFactory(GeneratorFactory):
     """
     Just the null generator
     """
-    def get_generators(self, column: Column, _engine: Engine):
+    def get_generators(self, columns: list[Column], engine: Engine):
+        if len(columns) != 1:
+            return []
+        column = columns[0]
         if column.nullable:
             return [ConstantGenerator(None)]
         c_type = get_column_type(column)

--- a/datafaker/generators.py
+++ b/datafaker/generators.py
@@ -945,14 +945,14 @@ class ChoiceGeneratorFactory(GeneratorFactory):
                         if type(v) is decimal.Decimal:
                             v = float(v)
                         values.append(v)
-                        cvs.append({"v": v, "count": c})
+                        cvs.append({"value": v, "count": c})
                     if self.SUPPRESS_COUNT < c:
                         counts_not_suppressed.append(c)
                         v = result.v
                         if type(v) is decimal.Decimal:
                             v = float(v)
                         values_not_suppressed.append(v)
-                        cvs_not_suppressed.append({"v": v, "count": c})
+                        cvs_not_suppressed.append({"value": v, "count": c})
                 if counts:
                     generators += [
                         ZipfChoiceGenerator(table_name, column_name, values, counts, sample_count=self.SAMPLE_COUNT),

--- a/datafaker/interactive.py
+++ b/datafaker/interactive.py
@@ -75,7 +75,7 @@ class AskSaveCmd(cmd.Cmd):
 
 
 class DbCmd(ABC, cmd.Cmd):
-    ERROR_NO_MORE_TABLES = "Error: There are no more tables"
+    INFO_NO_MORE_TABLES = "There are no more tables"
     ERROR_ALREADY_AT_START = "Error: Already at the start"
     ERROR_NO_SUCH_TABLE = "Error: '{0}' is not the name of a table in this database"
     ROW_COUNT_MSG = "Total row count: {}"
@@ -443,7 +443,7 @@ to exit this program."""
                 return
             self.set_table_index(index)
             return
-        self.next_table(self.ERROR_NO_MORE_TABLES)
+        self.next_table(self.INFO_NO_MORE_TABLES)
     def complete_next(self, text, line, begidx, endidx):
         return [
             entry.name
@@ -749,7 +749,7 @@ data from the database. Use 'quit' to exit this tool."""
                 return
             self.set_table_index(index)
             return
-        self.next_table(self.ERROR_NO_MORE_TABLES)
+        self.next_table(self.INFO_NO_MORE_TABLES)
     def complete_next(self, text, line, begidx, endidx):
         return [
             entry.name
@@ -1171,7 +1171,7 @@ information about the columns in the current table. Use 'peek',
             self.print("No more tables")
         next_gi = self.generator_index + 1
         if next_gi == len(table.new_generators):
-            self.next_table(self.ERROR_NO_MORE_TABLES)
+            self.next_table(self.INFO_NO_MORE_TABLES)
             return
         self.generator_index = next_gi
         self.set_prompt()
@@ -1220,7 +1220,7 @@ information about the columns in the current table. Use 'peek',
             self.generators = None
         if self.generators is None:
             columns = self.column_metadata()
-            gens = everything_factory.get_generators(columns, self.engine)
+            gens = everything_factory().get_generators(columns, self.engine)
             gens.sort(key=lambda g: g.fit(9999))
             self.generators = gens
             self.generators_valid_columns = (self.table_index, self.get_column_names().copy())
@@ -1252,7 +1252,10 @@ information about the columns in the current table. Use 'peek',
         args = arg.split()
         limit = 20
         comparison = {
-            "source": self._get_column_data(limit, to_str=str),
+            "source": [
+                x[0] if len(x) == 1 else ", ".join(x)
+                for x in self._get_column_data(limit, to_str=str)
+            ]
         }
         gens: list[Generator] = self._get_generator_proposals()
         table_name = self.table_name()

--- a/datafaker/interactive.py
+++ b/datafaker/interactive.py
@@ -846,6 +846,7 @@ information about the columns in the current table. Use 'peek',
     PRIMARY_PRIVATE_TEXT = "Primary Private"
     SECONDARY_PRIVATE_TEXT = "Secondary Private on columns {0}"
     NOT_PRIVATE_TEXT = "Not private"
+    ERROR_NO_SUCH_TABLE = "No such (non-vocabulary, non-ignored) table name {0}"
 
     def make_table_entry(self, table_name: str, table: Mapping) -> TableEntry | None:
         if table.get("ignore", False):
@@ -927,6 +928,8 @@ information about the columns in the current table. Use 'peek',
                 self.print("Internal error! table {0} does not have any generators!", self.table_index)
                 return False
             self.generator_index = len(table.generators) - 1
+        else:
+            self.print(self.ERROR_ALREADY_AT_START)
         return ret
 
     def get_table(self) -> GeneratorCmdTableEntry | None:
@@ -1121,7 +1124,7 @@ information about the columns in the current table. Use 'peek',
         parts = target.split(".", 1)
         table_index = self._get_table_index(parts[0])
         if table_index is None:
-            self.print("No such (non-vocabulary, non-ignored) table name {0}", parts[0])
+            self.print(self.ERROR_NO_SUCH_TABLE, parts[0])
             return False
         gen_index = None
         if 1 < len(parts) and parts[1]:
@@ -1156,7 +1159,7 @@ information about the columns in the current table. Use 'peek',
             self.print("No more tables")
         next_gi = self.generator_index + 1
         if next_gi == len(table.generators):
-            self.next_table()
+            self.next_table(self.ERROR_NO_MORE_TABLES)
             return
         self.generator_index = next_gi
         self.set_prompt()

--- a/datafaker/interactive.py
+++ b/datafaker/interactive.py
@@ -1487,9 +1487,20 @@ information about the columns in the current table. Use 'peek',
                     gen.columns.remove(tr)
                 # The existing generator (if any) will no longer work
                 gen.gen = None
-                # If we have deleted the last column, remove the entire generator entry
-                if not gen.columns:
-                    table_entry.new_generators.remove(gen)
+        # and remove any emptied generator entries
+        ng = table_entry.new_generators
+        i = 0
+        while i < self.generator_index:
+            if ng[i].columns:
+                i += 1
+            else:
+                ng = ng[:i] + ng[i + 1:]
+                self.generator_index -= 1
+        while i < len(ng):
+            if not ng[i].columns:
+                ng = ng[:i] + ng[i + 1:]
+            i += 1
+        table_entry.new_generators = ng
         # Add cols_to_merge to this generator
         gen_info.columns += cols
         gen_info.gen = None
@@ -1543,6 +1554,7 @@ information about the columns in the current table. Use 'peek',
             columns=cols,
             gen=None,
         ))
+        self.set_prompt()
 
     def complete_unmerge(self, text: str, _line: str, _begidx: int, _endidx: int):
         last_arg = text.split()[-1]

--- a/datafaker/interactive.py
+++ b/datafaker/interactive.py
@@ -851,6 +851,7 @@ information about the columns in the current table. Use 'peek',
     ERROR_NO_SUCH_TABLE = "No such (non-vocabulary, non-ignored) table name {0}"
     ERROR_NO_SUCH_COLUMN = "No such column {0} in this table"
     ERROR_COLUMN_ALREADY_MERGED = "Column {0} is already merged"
+    PROPOSE_NOTHING = "No proposed generators, sorry."
 
     def make_table_entry(self, table_name: str, table: Mapping) -> TableEntry | None:
         if table.get("ignore", False):
@@ -1371,6 +1372,8 @@ information about the columns in the current table. Use 'peek',
             self.print(self.PROPOSE_SOURCE_SAMPLE_TEXT, "; ".join(rep))
         else:
             self.print(self.PROPOSE_SOURCE_EMPTY_TEXT)
+        if not gens:
+            self.print(self.PROPOSE_NOTHING)
         for index, gen in enumerate(gens):
             fit = gen.fit()
             if fit is None:

--- a/datafaker/interactive.py
+++ b/datafaker/interactive.py
@@ -146,7 +146,9 @@ class DbCmd(ABC, cmd.Cmd):
         return self.metadata.tables[self.table_name()]
     def report_columns(self):
         self.print_table(["name", "type", "primary", "nullable", "foreign key"], [
-            [name, str(col.type), col.primary_key, col.nullable, ", ".join([fk.column.name for fk in col.foreign_keys])]
+            [name, str(col.type), col.primary_key, col.nullable, ", ".join(
+                [f"{fk.column.table.name}.{fk.column.name}" for fk in col.foreign_keys]
+            )]
             for name, col in self.table_metadata().columns.items()
         ])
     def get_table_config(self, table_name: str) -> dict[str, any]:
@@ -423,7 +425,7 @@ to exit this program."""
         if reply == "no":
             return True
         return False
-    def do_tables(self, arg):
+    def do_tables(self, _arg):
         "list the tables with their types"
         for entry in self.table_entries:
             old = entry.old_type
@@ -816,14 +818,13 @@ def update_missingness(src_dsn: str, src_schema: str, metadata: MetaData, config
 
 @dataclass
 class GeneratorInfo:
-    column: str
-    is_primary_key: bool
-    old_gen: Generator | None
-    new_gen: Generator | None
+    columns: list[str]
+    gen: Generator | None
 
 @dataclass
 class GeneratorCmdTableEntry(TableEntry):
-    generators: list[GeneratorInfo]
+    old_generators: list[GeneratorInfo]
+    new_generators: list[GeneratorInfo]
 
 class GeneratorCmd(DbCmd):
     intro = "Interactive generator configuration. Type ? for help.\n"
@@ -856,55 +857,50 @@ information about the columns in the current table. Use 'peek',
         if table.get("num_rows_per_pass", 1) == 0:
             return None
         metadata_table = self.metadata.tables[table_name]
-        columns = frozenset(metadata_table.columns.keys())
-        col2gen: dict[str, Generator] = {}
-        multiple_columns_assigned: dict[str, list[str]] = {}
+        columns = [str(colname) for colname in metadata_table.columns.keys()]
+        column_set = frozenset(columns)
+        columns_assigned_so_far = set()
+        new_generator_infos: list[GeneratorInfo] = []
+        old_generator_infos: list[GeneratorInfo] = []
         for rg in table.get("row_generators", []):
             gen_name = rg.get("name", None)
             if gen_name:
                 ca = rg.get("columns_assigned", [])
-                single_ca = None
-                if isinstance(ca, str):
-                    if ca not in columns:
-                        logger.warning(
-                            "table '%s' has '%s' assigned to column '%s' which is not in this table",
-                            table_name, gen_name, ca,
-                        )
-                    elif ca in col2gen:
-                        logger.warning(
-                            "table '%s' has column '%s' assigned to multiple times",
-                            table_name, ca,
-                        )
-                    else:
-                        single_ca = ca
-                else:
-                    if len(ca) == 1:
-                        single_ca = str(ca[0])
-                if single_ca is not None:
-                    col2gen[single_ca] = PredefinedGenerator(table, rg, self.config)
-                else:
-                    multiple_columns_assigned[gen_name] = ca
-        generator_infos: list[GeneratorInfo] = []
-        for name, col in metadata_table.columns.items():
-            gen = col2gen.get(name, None)
-            generator_infos.append(GeneratorInfo(
-                column=str(name),
-                is_primary_key=col.primary_key,
-                old_gen=gen,
-                new_gen=gen,
-            ))
-        if multiple_columns_assigned:
-            self.print(
-                "The following mulit-column generators for table {0} are defined in the configuration file and cannot be configured with this command",
-                table_name,
-            )
-            for (gen_name, cols) in multiple_columns_assigned.items():
-                self.print("   {0}: {1}", gen_name, cols)
-        if len(generator_infos) == 0:
+                collist: list[str] = [ca] if isinstance(ca, str) else [str(c) for c in ca]
+                colset: set[str] = set(collist)
+                for unknown in colset - column_set:
+                    logger.warning(
+                        "table '%s' has '%s' assigned to column '%s' which is not in this table",
+                        table_name, gen_name, unknown
+                    )
+                for mult in columns_assigned_so_far & colset:
+                    logger.warning(
+                        "table '%s' has column '%s' assigned to multiple times", table_name, mult
+                    )
+                actual_collist = [c for c in collist if c in columns]
+                if actual_collist:
+                    gen = PredefinedGenerator(table, rg, self.config)
+                    new_generator_infos.append(GeneratorInfo(
+                        columns=actual_collist.copy(),
+                        gen=gen,
+                    ))
+                    old_generator_infos.append(GeneratorInfo(
+                        columns=actual_collist.copy(),
+                        gen=gen,
+                    ))
+                    columns_assigned_so_far |= colset
+        for colname in columns:
+            if colname not in columns_assigned_so_far:
+                new_generator_infos.append(GeneratorInfo(
+                    columns=[colname],
+                    gen=None,
+                ))
+        if len(new_generator_infos) == 0:
             return None
         return GeneratorCmdTableEntry(
             name=table_name,
-            generators=generator_infos
+            old_generators=old_generator_infos,
+            new_generators=new_generator_infos,
         )
 
     def __init__(self, src_dsn: str, src_schema: str, metadata: MetaData, config: Mapping):
@@ -927,7 +923,7 @@ information about the columns in the current table. Use 'peek',
             if table is None:
                 self.print("Internal error! table {0} does not have any generators!", self.table_index)
                 return False
-            self.generator_index = len(table.generators) - 1
+            self.generator_index = len(table.new_generators) - 1
         else:
             self.print(self.ERROR_ALREADY_AT_START)
         return ret
@@ -939,22 +935,24 @@ information about the columns in the current table. Use 'peek',
 
     def get_table_and_generator(self) -> tuple[str | None, GeneratorInfo | None]:
         if self.table_index < len(self.table_entries):
-            entry = self.table_entries[self.table_index]
-            if self.generator_index < len(entry.generators):
-                return (entry.name, entry.generators[self.generator_index])
+            entry: GeneratorCmdTableEntry = self.table_entries[self.table_index]
+            if self.generator_index < len(entry.new_generators):
+                return (entry.name, entry.new_generators[self.generator_index])
             return (entry.name, None)
         return (None, None)
 
-    def get_column_name(self) -> str | None:
+    def get_column_names(self) -> list[str]:
         (_, generator_info) = self.get_table_and_generator()
-        return generator_info.column if generator_info else None
+        return generator_info.columns if generator_info else []
 
-    def column_metadata(self) -> Column | None:
+    def column_metadata(self) -> list[Column]:
         table = self.table_metadata()
-        column_name = self.get_column_name()
-        if table is None or column_name is None:
-            return None
-        return table.columns[column_name]
+        if table is None:
+            return []
+        return [
+            table.columns[name]
+            for name in self.get_column_names()
+        ]
 
     def set_prompt(self):
         (table_name, gen_info) = self.get_table_and_generator()
@@ -964,21 +962,13 @@ information about the columns in the current table. Use 'peek',
         if gen_info is None:
             self.prompt = "({table}) ".format(table=table_name)
             return
-        if gen_info.is_primary_key:
-            column = f"{gen_info.column}[pk]"
-        else:
-            column = gen_info.column
-        if gen_info.new_gen:
-            self.prompt = "({table}.{column} ({generator})) ".format(
-                table=table_name,
-                column=column,
-                generator=gen_info.new_gen.name(),
-            )
-        else:
-            self.prompt = "({table}.{column}) ".format(
-                table=table_name,
-                column=column,
-            )
+        table = self.table_metadata()
+        columns = [
+            c + "[pk]" if table.columns[c].primary_key else c
+            for c in gen_info.columns
+        ]
+        gen = f" ({gen_info.gen.name()})" if gen_info.gen else ""
+        self.prompt = f"({table_name}.{','.join(columns)}{gen}) "
 
     def _remove_auto_src_stats(self) -> list[dict[str, any]]:
         return self._remove_prefix_src_stats("auto__")
@@ -989,10 +979,10 @@ information about the columns in the current table. Use 'peek',
         for entry in tes:
             rgs = []
             new_gens: list[Generator] = []
-            for generator in entry.generators:
-                if generator.new_gen is not None:
-                    new_gens.append(generator.new_gen)
-                    cqs = generator.new_gen.custom_queries()
+            for generator in entry.new_generators:
+                if generator.gen is not None:
+                    new_gens.append(generator.gen)
+                    cqs = generator.gen.custom_queries()
                     for cq_key, cq in cqs.items():
                         src_stats.append({
                             "name": cq_key,
@@ -1000,10 +990,10 @@ information about the columns in the current table. Use 'peek',
                             "comments": [cq["comment"]] if "comment" in cq and cq["comment"] else [],
                         })
                     rg = {
-                        "name": generator.new_gen.function_name(),
-                        "columns_assigned": [generator.column],
+                        "name": generator.gen.function_name(),
+                        "columns_assigned": generator.columns,
                     }
-                    kwn = generator.new_gen.nominal_kwargs()
+                    kwn = generator.gen.nominal_kwargs()
                     if kwn:
                         rg["kwargs"] = kwn
                     rgs.append(rg)
@@ -1027,23 +1017,33 @@ information about the columns in the current table. Use 'peek',
             self.set_table_config(entry.name, table_config)
         self.config["src-stats"] = src_stats
 
+    def _find_old_generator(self, entry: GeneratorCmdTableEntry, columns) -> Generator | None:
+        """ Find any generator that previously assigned to these exact same columns. """
+        fc = frozenset(columns)
+        for gen in entry.old_generators:
+            if frozenset(gen.columns) == fc:
+                return gen.gen
+        return None
+
     def do_quit(self, arg):
         "Check the updates, save them if desired and quit the configurer."
         count = 0
         for entry in self.table_entries:
             header_shown = False
             g_entry: GeneratorCmdTableEntry = entry
-            for gen in g_entry.generators:
-                if gen.old_gen != gen.new_gen:
+            for gen in g_entry.new_generators:
+                old_gen = self._find_old_generator(g_entry, gen.columns)
+                new_gen = None if gen is None else gen.gen
+                if old_gen != new_gen:
                     if not header_shown:
                         header_shown = True
                         self.print("Table {0}:", entry.name)
                     count += 1
                     self.print(
                         "...changing {0} from {1} to {2}",
-                        gen.column,
-                        gen.old_gen.name() if gen.old_gen else "nothing",
-                        gen.new_gen.name() if gen.new_gen else "nothing",
+                        ", ".join(gen.columns),
+                        old_gen.name() if old_gen else "nothing",
+                        gen.gen.name() if gen.gen else "nothing",
                     )
         if count == 0:
             self.print("You have made no changes.")
@@ -1061,7 +1061,7 @@ information about the columns in the current table. Use 'peek',
     def do_tables(self, arg):
         "list the tables"
         for entry in self.table_entries:
-            gen_count = len(entry.generators)
+            gen_count = len(entry.new_generators)
             how_many = "one generator" if gen_count == 1 else f"{gen_count} generators"
             self.print("{0} ({1})", entry.name, how_many)
 
@@ -1070,18 +1070,23 @@ information about the columns in the current table. Use 'peek',
         if len(self.table_entries) <= self.table_index:
             self.print("Error: no table {0}", self.table_index)
             return
-        for gen in self.table_entries[self.table_index].generators:
-            old = "" if gen.old_gen is None else gen.old_gen.name()
-            if gen.old_gen == gen.new_gen:
+        g_entry: GeneratorCmdTableEntry = self.table_entries[self.table_index]
+        table = self.table_metadata()
+        for gen in g_entry.new_generators:
+            old_gen = self._find_old_generator(g_entry, gen.columns)
+            old = "" if old_gen is None else old_gen.name()
+            if old_gen == gen.gen:
                 becomes = ""
                 if old == "":
                     old = "(not set)"
-            elif gen.new_gen is None:
+            elif gen.gen is None:
                 becomes = "(delete)"
             else:
-                becomes = f"->{gen.new_gen.name()}"
-            primary = "[primary-key]" if gen.is_primary_key else ""
-            self.print("{0}{1}{2} {3}", old, becomes, primary, gen.column)
+                becomes = f"->{gen.gen.name()}"
+            primary = ""
+            if len(gen.columns) == 1 and table.columns[gen.columns[0]].primary_key:
+                primary = "[primary-key]"
+            self.print("{0}{1}{2} {3}", old, becomes, primary, gen.columns)
 
     def do_columns(self, _arg):
         "Report the column names and metadata"
@@ -1089,23 +1094,21 @@ information about the columns in the current table. Use 'peek',
 
     def do_info(self, _arg):
         "Show information about the current column"
-        cm = self.column_metadata()
-        if cm is None:
-            return
-        self.print(
-            "Column {0} in table {1} has type {2} ({3}).",
-            cm.name,
-            cm.table.name,
-            str(cm.type),
-            "nullable" if cm.nullable else "not nullable",
-        )
-        if cm.primary_key:
-            self.print("It is a primary key, which usually does not need a generator")
-        elif cm.foreign_keys:
-            fk_names = [fk.column.name for fk in cm.foreign_keys]
-            self.print("It is a foreign key referencing table {0}", ", ".join(fk_names))
-            if len(fk_names) == 1:
-                self.print("You do not need a generator if you just want a uniform choice over the referenced table's rows")
+        for cm in self.column_metadata():
+            self.print(
+                "Column {0} in table {1} has type {2} ({3}).",
+                cm.name,
+                cm.table.name,
+                str(cm.type),
+                "nullable" if cm.nullable else "not nullable",
+            )
+            if cm.primary_key:
+                self.print("It is a primary key, which usually does not need a generator")
+            elif cm.foreign_keys:
+                fk_names = [fk.column.name for fk in cm.foreign_keys]
+                self.print("It is a foreign key referencing table {0}", ", ".join(fk_names))
+                if len(fk_names) == 1:
+                    self.print("You do not need a generator if you just want a uniform choice over the referenced table's rows")
 
     def _get_table_index(self, table_name: str) -> int | None:
         for n, entry in enumerate(self.table_entries):
@@ -1115,8 +1118,8 @@ information about the columns in the current table. Use 'peek',
 
     def _get_generator_index(self, table_index, column_name):
         entry: GeneratorCmdTableEntry = self.table_entries[table_index]
-        for n, gen in enumerate(entry.generators):
-            if gen.column == column_name:
+        for n, gen in enumerate(entry.new_generators):
+            if column_name in gen.columns:
                 return n
         return None
 
@@ -1158,7 +1161,7 @@ information about the columns in the current table. Use 'peek',
         if table is None:
             self.print("No more tables")
         next_gi = self.generator_index + 1
-        if next_gi == len(table.generators):
+        if next_gi == len(table.new_generators):
             self.next_table(self.ERROR_NO_MORE_TABLES)
             return
         self.generator_index = next_gi
@@ -1174,9 +1177,10 @@ information about the columns in the current table. Use 'peek',
                 return []
             table_entry: GeneratorCmdTableEntry = self.table_entries[table_index]
             return [
-                f"{table_name}.{gen.column}"
-                for gen in table_entry.generators
-                if gen.column.startswith(column_name)
+                f"{table_name}.{column}"
+                for gen in table_entry.new_generators
+                for column in gen.columns
+                if column.startswith(column_name)
             ]
         table_names = [
             entry.name
@@ -1206,11 +1210,8 @@ information about the columns in the current table. Use 'peek',
         if not self._generators_valid():
             self.generators = None
         if self.generators is None:
-            column = self.column_metadata()
-            if column is None:
-                logger.error("No such column")
-                return []
-            gens = everything_factory.get_generators(column, self.engine)
+            columns = self.column_metadata()
+            gens = everything_factory.get_generators(columns, self.engine)
             gens.sort(key=lambda g: g.fit(9999))
             self.generators = gens
             self.generators_valid_indices = (self.table_index, self.generator_index)
@@ -1332,24 +1333,15 @@ information about the columns in the current table. Use 'peek',
         select_q = self._get_aggregate_query([gen], table_name)
         self.print("{0}; providing the following values: {1}", select_q, vals)
 
-    def _get_column_data(self, count: int, to_str=repr, min_length: int = 0):
-        column = str(self.get_column_name())
-        where = f"WHERE {column} IS NOT NULL"
-        if 0 < min_length:
-            where = "WHERE LENGTH({column}) >= {len}".format(
-                column=column,
-                len=min_length,
-            )
+    def _get_column_data(self, count: int, to_str=repr):
+        columns = self.get_column_names()
+        columns_string = ", ".join(columns)
+        pred = " AND ".join(f"{column} IS NOT NULL" for column in columns)
         with self.engine.connect() as connection:
             result = connection.execute(
-                text("SELECT {column} FROM {table} {where} ORDER BY RANDOM() LIMIT {count}".format(
-                    table=self.table_name(),
-                    column=column,
-                    count=count,
-                    where=where,
-                ))
+                text(f"SELECT {columns_string} FROM {self.table_name()} WHERE {pred} ORDER BY RANDOM() LIMIT {count}")
             )
-            return [to_str(x[0]) for x in result.all()]
+            return [to_str(x) for xs in result.all() for x in xs]
 
     def do_propose(self, _arg):
         """
@@ -1363,7 +1355,11 @@ information about the columns in the current table. Use 'peek',
         gens = self._get_generator_proposals()
         sample = self._get_column_data(limit)
         if sample:
-            self.print(self.PROPOSE_SOURCE_SAMPLE_TEXT, ",".join(sample))
+            rep = [
+                x[0] if len(x) == 1 else x
+                for x in sample
+            ]
+            self.print(self.PROPOSE_SOURCE_SAMPLE_TEXT, ",".join(rep))
         else:
             self.print(self.PROPOSE_SOURCE_EMPTY_TEXT)
         for index, gen in enumerate(gens):
@@ -1422,7 +1418,7 @@ information about the columns in the current table. Use 'peek',
         if gen_info is None:
             self.print("Error: no column")
             return
-        gen_info.new_gen = new_gen
+        gen_info.gen = new_gen
         self._go_next()
 
     def do_s(self, arg):
@@ -1440,7 +1436,7 @@ information about the columns in the current table. Use 'peek',
         if gen_info is None:
             self.print("Error: no column")
             return
-        gen_info.new_gen = None
+        gen_info.gen = None
         self._go_next()
 
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -125,6 +125,8 @@ Note that the prompt here is ``(table: myfirsttable)``. This will be different o
 Tab completion
 ^^^^^^^^^^^^^^
 
+For the following examples we will be using the `Pagila <https://github.com/devrimgunduz/pagila>`_ database.
+
 You can use the Tab key on your keyboard to shorten these commands. Try typing h-tab-space-v-tab-return, and you will get ``help vocabulary`` again.
 Some commands require a little more. Try typing h-tab-p-tab and you will see that the ``p`` does not get expanded to ``private`` because there is more than one possibility (it could be ``peek`` or ``previous``).
 Press the Tab key again to see these options:
@@ -278,6 +280,54 @@ Short commands
 
 In case you couldn't get tab completion working on your favourite terminal on your machine, there are single letter commands for the most common operations of ``configure-generators``:
 ``n`` and ``b`` are synonymns for ``next`` and ``previous`` ("back"), and ``p``, ``c`` and ``s`` are synonymns for ``propose``, ``compare`` and ``set`` respectively.
+
+Multivariate generators
+^^^^^^^^^^^^^^^^^^^^^^^
+
+So far we have been talking about generators that generate one column in isolation.
+If we want columns that are not independent we will need to merge generators.
+Let us merge the width and height of the artwork so that we can generate larger widths when we have larger heights.
+
+For this example we will use the `database of artworks from the Museam of Modern Art in New York<https://github.com/MuseumofModernArt/collection>`_.
+
+.. code-block:: console
+
+   (artist.artist_bio) next artwork.width_cm
+   (artwork.width_cm) merge height_cm
+   (artwork.width_cm,height_cm) propose
+   Sample of actual source data: Decimal('16.2'),Decimal('22.4'); Decimal('116.8402336805'),Decimal('86.3601727203'); Decimal('22.5'),Decimal('16.7'); Decimal('14.8'),Decimal('12.0'); Decimal('33.0'),Decimal('41.0')...
+   1. dist_gen.multivariate_normal: (no fit) [24.218647620979098, 7.360975395642008]; [-25.66672699079883, 6.305174473450588]; [51.9325078591789, 50.400909869916106]; [-36.8172785399614, -8.764753035274687]; [-6.686185021449695, -4.329031921751557] ...
+   (artwork.width_cm,height_cm) compare 1
+   Not private
+   2. dist_gen.multivariate_normal requires the following data from the source database:
+   {'comment': 'Means and covariate matrix for the columns width_cm, height_cm, so that we can produce the relatedness between these in the fake data.', 'query': 'SELECT q.m0, q.m1, (q.s0_0 - q.count * q.m0 * q.m0)/(q.count - 1) AS c0_0, (q.s0_1 - q.count * q.m0 * q.m1)/(q.count - 1) AS c0_1, (q.s1_1 - q.count * q.m1 * q.m1)/(q.count - 1) AS c1_1, 2 AS rank FROM (SELECT COUNT(*) AS count, SUM(width_cm * width_cm) AS s0_0, SUM(width_cm * height_cm) AS s0_1, SUM(height_cm * height_cm) AS s1_1, AVG(width_cm) AS m0, AVG(height_cm) AS m1 FROM artwork WHERE width_cm IS NOT NULL AND height_cm IS NOT NULL) AS q'}; providing the following values: [{'m0': Decimal('39.8408881695503020'), 'm1': Decimal('37.8942602940080112'), 'c0_0': Decimal('8566.13996292591607014145908725748824'), 'c0_1': Decimal('1771.51432112064062574103021748260967'), 'c1_1': Decimal('2434.30506961622772921636781436857116'), 'rank': 2}]
+   +------------------------------------+--------------------------------------------+
+   |               source               |      1. dist_gen.multivariate_normal       |
+   +------------------------------------+--------------------------------------------+
+   |          ['51.0', '25.3']          |  [107.62299759565568, 37.35577315694575]   |
+   |          ['44.5', '30.5']          |  [152.92767947123627, 58.16764808196753]   |
+   |           ['2.7', '1.4']           |  [56.330025279386106, -33.96974465059194]  |
+   |          ['22.9', '30.0']          |  [107.26687687006478, -3.97940090777724]   |
+   |          ['63.0', '47.0']          |  [2.3866753797989446, 12.881616830761228]  |
+   |          ['76.7', '56.1']          |  [64.25340675261016, -29.273930592763726]  |
+   |          ['20.8', '23.4']          |  [-8.995270515356808, -7.705664324666984]  |
+   |          ['12.6', '17.6']          |  [34.178077659717836, 94.70620393166871]   |
+   |          ['25.2', '16.1']          | [-123.37431991776657, -28.507489258163467] |
+   |          ['56.4', '76.0']          |  [6.060190508953035, 107.64705861417013]   |
+   |          ['47.0', '60.3']          |   [42.1814314824603, 25.618930675417985]   |
+   |     ['28.8925577851', '38.4']      |    [-2.5661114817431, 42.6582049225207]    |
+   |          ['13.8', '17.8']          |  [-68.31635612312357, 71.04694634347027]   |
+   |          ['25.0', '35.1']          |  [-22.950164218800843, 71.28958248545288]  |
+   | ['76.2001524003', '50.8001016002'] |  [47.8174777970675, -25.945373592062154]   |
+   |          ['58.0', '39.0']          |  [45.99046685957763, 23.657508524854045]   |
+   |          ['22.3', '30.2']          |  [-34.78167099385892, -83.23940863318586]  |
+   |          ['20.3', '19.7']          |  [63.65436136383347, 23.447379421706685]   |
+   | ['28.4163068326', '21.7487934976'] |  [158.41474989518605, 74.15055440725314]   |
+   |          ['17.9', '23.8']          |   [100.0788055327166, 46.13183648219197]   |
+   +------------------------------------+--------------------------------------------+
+
+And now we can ``set 1`` as usual.
+We can see that large widths and heights generally go together, but unfortunately we get many negative lengths and widths.
 
 Configuring missingness
 -----------------------

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -56,7 +56,7 @@ class ConfigureTablesSrcTests(ConfigureTablesTests):
             for t in table_names:
                 self.assertIn(t, tc.prompt)
                 tc.do_next("")
-            self.assertListEqual(tc.messages, [(TableCmd.ERROR_NO_MORE_TABLES, (), {})])
+            self.assertListEqual(tc.messages, [(TableCmd.INFO_NO_MORE_TABLES, (), {})])
             tc.reset()
             for t in reversed(table_names):
                 self.assertIn(t, tc.prompt)
@@ -406,7 +406,7 @@ class ConfigureGeneratorsTests(RequiresDBTestCase):
                     else:
                         self.assertNotIn("[pk]", gc.prompt)
                     gc.do_next("")
-            self.assertListEqual(gc.messages, [(GeneratorCmd.ERROR_NO_MORE_TABLES, (), {})])
+            self.assertListEqual(gc.messages, [(GeneratorCmd.INFO_NO_MORE_TABLES, (), {})])
             gc.reset()
             for table_name, table_meta in reversed(list(self.metadata.tables.items())):
                 for column_name, column_meta in reversed(list(table_meta.columns.items())):
@@ -970,7 +970,7 @@ class GeneratorTests(GeneratesDBTestCase):
             gc.do_next("signature_model.based_on")
             gc.do_set("dist_gen.constant")
             # we have got to the end of the columns, but shouldn't have any errors
-            self.assertListEqual(gc.messages, [(GeneratorCmd.ERROR_NO_MORE_TABLES, (), {})])
+            self.assertListEqual(gc.messages, [(GeneratorCmd.INFO_NO_MORE_TABLES, (), {})])
             gc.reset()
             gc.do_quit("")
             config = gc.config

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -924,7 +924,14 @@ class GeneratorsOutputTests(GeneratesDBTestCase):
             self.assertIn("dist_gen.weighted_choice", proposals)
             self.assertIn("dist_gen.weighted_choice [sampled]", proposals)
             self.assertIn("dist_gen.weighted_choice [sampled and suppressed]", proposals)
-            gc.do_set(str(proposals["dist_gen.weighted_choice [sampled and suppressed]"][0]))
+            prop = proposals["dist_gen.weighted_choice [sampled and suppressed]"]
+            self.assertSubset(set(prop[2]), {"1", "4"})
+            gc.reset()
+            gc.do_compare(str(prop[0]))
+            col_heading = f"{prop[0]}. dist_gen.weighted_choice [sampled and suppressed]"
+            self.assertIn(col_heading, set(gc.columns.keys()))
+            self.assertSubset(set(gc.columns[col_heading]), {1, 4})
+            gc.do_set(str(prop[0]))
             gc.do_next("number_table.two")
             gc.reset()
             gc.do_propose("")
@@ -932,7 +939,14 @@ class GeneratorsOutputTests(GeneratesDBTestCase):
             self.assertIn("dist_gen.weighted_choice", proposals)
             self.assertIn("dist_gen.weighted_choice [sampled]", proposals)
             self.assertIn("dist_gen.weighted_choice [sampled and suppressed]", proposals)
-            gc.do_set(str(proposals["dist_gen.weighted_choice"][0]))
+            prop = proposals["dist_gen.weighted_choice"]
+            self.assertSubset(set(prop[2]), {"1", "2", "3", "4", "5"})
+            gc.reset()
+            gc.do_compare(str(prop[0]))
+            col_heading = f"{prop[0]}. dist_gen.weighted_choice"
+            self.assertIn(col_heading, set(gc.columns.keys()))
+            self.assertSubset(set(gc.columns[col_heading]), {1, 2, 3, 4, 5})
+            gc.do_set(str(prop[0]))
             gc.do_next("number_table.three")
             gc.reset()
             gc.do_propose("")
@@ -940,7 +954,13 @@ class GeneratorsOutputTests(GeneratesDBTestCase):
             self.assertIn("dist_gen.weighted_choice", proposals)
             self.assertIn("dist_gen.weighted_choice [sampled]", proposals)
             self.assertNotIn("dist_gen.weighted_choice [sampled and suppressed]", proposals)
-            gc.do_set(str(proposals["dist_gen.weighted_choice [sampled]"][0]))
+            prop = proposals["dist_gen.weighted_choice [sampled]"]
+            self.assertSubset(set(prop[2]), {"1", "2", "3", "4", "5"})
+            gc.do_compare(str(prop[0]))
+            col_heading = f"{prop[0]}. dist_gen.weighted_choice [sampled]"
+            self.assertIn(col_heading, set(gc.columns.keys()))
+            self.assertSubset(set(gc.columns[col_heading]), {1, 2, 3, 4, 5})
+            gc.do_set(str(prop[0]))
             gc.do_quit("")
             self.generate_data(gc.config, num_passes=200)
         with self.engine.connect() as conn:

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -891,7 +891,7 @@ class GeneratorTests(GeneratesDBTestCase):
             gc.do_next("signature_model.based_on")
             gc.do_set("dist_gen.constant")
             # we have got to the end of the columns, but shouldn't have any errors
-            self.assertListEqual(gc.messages, [("No more tables", (), {})])
+            self.assertListEqual(gc.messages, [(GeneratorCmd.ERROR_NO_MORE_TABLES, (), {})])
             gc.reset()
             gc.do_quit("")
             config = gc.config

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -73,6 +73,33 @@ class DatafakerTestCase(TestCase):
             return
         self.fail(''.join(traceback.format_exception(result.exception)))
 
+    def assertSubset(self, set1, set2, msg=None):
+        """Assert a set is a (non-strict) subset.
+
+        Args:
+            set1: The asserted subset.
+            set2: The asserted superset.
+            msg: Optional message to use on failure instead of a list of
+                    differences.
+        """
+        try:
+            difference = set1.difference(set2)
+        except TypeError as e:
+            self.fail('invalid type when attempting set difference: %s' % e)
+        except AttributeError as e:
+            self.fail('first argument does not support set difference: %s' % e)
+
+        if not difference:
+            return
+
+        lines = []
+        if difference:
+            lines.append('Items in the first set but not the second:')
+            for item in difference:
+                lines.append(repr(item))
+
+        standardMsg = '\n'.join(lines)
+        self.fail(self._formatMessage(msg, standardMsg))
 
 @skipUnless(shutil.which("psql"), "need to find 'psql': install PostgreSQL to enable")
 class RequiresDBTestCase(DatafakerTestCase):


### PR DESCRIPTION
Added new commands to `configure-generators`: `merge col1 col2 col3` and `unmerge col1 col2 col3`. You can use `merge` to configure a generator that spans multiple columns (and `unmerge` to separate the columns out again).

If you merge multiple numeric columns, `propose` will now offer you `multivariate_normal` and `multivariate_lognormal`, which  grab covariates from the source database and produce similarly covariant fake data for the output database.

We also have a univariate lognormal, and a weighted choice distribution!

I built this as a half-way house towards EAVs, but maybe someone wants this on its own.

Fixes #54 