### PR TITLE
configure-generators --spec now allows fallbacks

### DIFF
--- a/datafaker/generators.py
+++ b/datafaker/generators.py
@@ -944,7 +944,7 @@ class ChoiceGeneratorFactory(GeneratorFactory):
     All generators that want an average and standard deviation.
     """
     SAMPLE_COUNT = MAXIMUM_CHOICES
-    SUPPRESS_COUNT = 5
+    SUPPRESS_COUNT = 7
     def get_generators(self, columns: list[Column], engine: Engine):
         if len(columns) != 1:
             return []
@@ -1511,7 +1511,7 @@ class NullPatternPartition:
 
 class NullPartitionedNormalGeneratorFactory(MultivariateNormalGeneratorFactory):
     SAMPLE_COUNT = MAXIMUM_CHOICES
-    SUPPRESS_COUNT = 5
+    SUPPRESS_COUNT = 7
 
     def function_name(self) -> str:
         return "grouped_multivariate_normal"

--- a/datafaker/generators.py
+++ b/datafaker/generators.py
@@ -1567,6 +1567,8 @@ class NullPartitionedNormalGeneratorFactory(MultivariateNormalGeneratorFactory):
         query_name = f"{table}__{columns[0].name}"
         # Partitions for minimal suppression and no sampling
         row_partitions_maximal: dict[int, RowPartition] = {}
+        # Partitions for minimal suppression but sampling
+        row_partitions_sampled: dict[int, RowPartition] = {}
         # Partitions for normal suppression and severe sampling
         row_partitions_ss: dict[int, RowPartition] = {}
         for partition_nonnulls in powerset(nullable_columns):
@@ -1580,6 +1582,23 @@ class NullPartitionedNormalGeneratorFactory(MultivariateNormalGeneratorFactory):
                 constant_clauses=partition_def.constant_clauses,
             )
             row_partitions_maximal[partition_def.index] = RowPartition(
+                query,
+                partition_def.included_numeric,
+                partition_def.included_choice,
+                partition_def.excluded,
+                partition_def.nones,
+                {},
+            )
+            query = self.query(
+                table=table,
+                columns=partition_def.included_numeric,
+                predicates=partition_def.predicates,
+                group_by_clause=partition_def.group_by_clause,
+                constants = partition_def.constants,
+                constant_clauses=partition_def.constant_clauses,
+                sample_count=self.SAMPLE_COUNT,
+            )
+            row_partitions_sampled[partition_def.index] = RowPartition(
                 query,
                 partition_def.included_numeric,
                 partition_def.included_choice,
@@ -1618,6 +1637,16 @@ class NullPartitionedNormalGeneratorFactory(MultivariateNormalGeneratorFactory):
                         query_name,
                         row_partitions_maximal,
                         self.function_name(),
+                        partition_count_query=partition_query_max,
+                        partition_counts=partition_count_max_results,
+                        partition_count_comment=count_comment,
+                    ))
+                if self._execute_partition_queries(connection, row_partitions_sampled):
+                    gens.append(NullPartitionedNormalGenerator(
+                        query_name,
+                        row_partitions_sampled,
+                        self.function_name(),
+                        name_suffix="sampled",
                         partition_count_query=partition_query_max,
                         partition_counts=partition_count_max_results,
                         partition_count_comment=count_comment,

--- a/datafaker/generators.py
+++ b/datafaker/generators.py
@@ -1573,7 +1573,7 @@ class NullPartitionedNormalGeneratorFactory(MultivariateNormalGeneratorFactory):
         row_partitions_ss: dict[int, RowPartition] = {}
         for partition_nonnulls in powerset(nullable_columns):
             partition_def = NullPatternPartition(columns, partition_nonnulls)
-            query = self.query(
+            query_all = self.query(
                 table=table,
                 columns=partition_def.included_numeric,
                 predicates=partition_def.predicates,
@@ -1582,14 +1582,14 @@ class NullPartitionedNormalGeneratorFactory(MultivariateNormalGeneratorFactory):
                 constant_clauses=partition_def.constant_clauses,
             )
             row_partitions_maximal[partition_def.index] = RowPartition(
-                query,
+                query_all,
                 partition_def.included_numeric,
                 partition_def.included_choice,
                 partition_def.excluded,
                 partition_def.nones,
                 {},
             )
-            query = self.query(
+            query_sampled = self.query(
                 table=table,
                 columns=partition_def.included_numeric,
                 predicates=partition_def.predicates,
@@ -1599,14 +1599,14 @@ class NullPartitionedNormalGeneratorFactory(MultivariateNormalGeneratorFactory):
                 sample_count=self.SAMPLE_COUNT,
             )
             row_partitions_sampled[partition_def.index] = RowPartition(
-                query,
+                query_sampled,
                 partition_def.included_numeric,
                 partition_def.included_choice,
                 partition_def.excluded,
                 partition_def.nones,
                 {},
             )
-            query = self.query(
+            query_ss = self.query(
                 table=table,
                 columns=partition_def.included_numeric,
                 predicates=partition_def.predicates,
@@ -1617,7 +1617,7 @@ class NullPartitionedNormalGeneratorFactory(MultivariateNormalGeneratorFactory):
                 sample_count=self.SAMPLE_COUNT,
             )
             row_partitions_ss[partition_def.index] = RowPartition(
-                query,
+                query_ss,
                 partition_def.included_numeric,
                 partition_def.included_choice,
                 partition_def.excluded,

--- a/tests/examples/eav.sql
+++ b/tests/examples/eav.sql
@@ -22,8 +22,8 @@ INSERT INTO public.measurement_type VALUES (5, 'matter');
 CREATE TABLE public.measurement (
     id INTEGER NOT NULL,
     type INTEGER NOT NULL,
-    first_value INTEGER,
-    second_value INTEGER,
+    first_value FLOAT,
+    second_value FLOAT,
     third_value TEXT
 );
 
@@ -57,8 +57,8 @@ INSERT INTO public.measurement VALUES (20, 5, 12.4, NULL, 'fowl');
 CREATE TABLE public.observation (
     id INTEGER NOT NULL,
     type INTEGER NOT NULL,
-    first_value INTEGER,
-    second_value INTEGER,
+    first_value FLOAT,
+    second_value FLOAT,
     third_value TEXT
 );
 

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -1462,8 +1462,9 @@ class NonInteractiveTests(RequiresDBTestCase):
 
     @patch("datafaker.interactive.Path")
     @patch("datafaker.interactive.csv.reader", return_value=iter([
-        ["observation", "type", "dist_gen.weighted_choice"],
-        ["observation", "first_value", "dist_gen.weighted_choice"],
+        ["observation", "type", "dist_gen.weighted_choice [sampled]"],
+        ["observation", "first_value", "dist_gen.weighted_choice", "dist_gen.constant"],
+        ["observation", "second_value", "dist_gen.weighted_choice", "dist_gen.weighted_choice [sampled]", "dist_gen.constant"],
         ["observation", "third_value", "dist_gen.weighted_choice"],
     ]))
     def test_non_interactive_configure_generators(self, mock_csv_reader: MagicMock, mock_path: MagicMock):
@@ -1480,4 +1481,5 @@ class NonInteractiveTests(RequiresDBTestCase):
         }
         self.assertEqual(row_gens["observation['type']"], "dist_gen.weighted_choice")
         self.assertEqual(row_gens["observation['first_value']"], "dist_gen.weighted_choice")
+        self.assertEqual(row_gens["observation['second_value']"], "dist_gen.constant")
         self.assertEqual(row_gens["observation['third_value']"], "dist_gen.weighted_choice")

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -12,7 +12,10 @@ from datafaker.interactive import (
     MissingnessCmd,
     update_config_generators,
 )
-from datafaker.generators import NullPartitionedNormalGeneratorFactory
+from datafaker.generators import (
+    NullPartitionedNormalGeneratorFactory,
+    ChoiceGeneratorFactory,
+)
 
 from tests.utils import RequiresDBTestCase, GeneratesDBTestCase
 from unittest.mock import MagicMock, Mock, patch
@@ -841,6 +844,11 @@ class GeneratorsOutputTests(GeneratesDBTestCase):
     database_name = "numbers"
     schema_name = "public"
 
+    def setUp(self) -> None:
+        super().setUp()
+        ChoiceGeneratorFactory.SAMPLE_COUNT = 500
+        ChoiceGeneratorFactory.SUPPRESS_COUNT = 5
+
     def _get_cmd(self, config) -> TestGeneratorCmd:
         return TestGeneratorCmd(self.dsn, self.schema_name, self.metadata, config)
 
@@ -1314,16 +1322,16 @@ class NullPartitionedTests(GeneratesDBTestCase):
             # type 2
             self.assertAlmostEqual(two.count(), generate_count * 3 / 20, delta=generate_count * 0.5)
             self.assertAlmostEqual(two.x_mean(), 1.4, delta=0.6)
-            self.assertAlmostEqual(two.x_var(), 0.21, delta=0.4)
+            self.assertAlmostEqual(two.x_var(), 0.14, delta=0.2)
             self.assertAlmostEqual(two.y_mean(), 1.8, delta=0.8)
-            self.assertAlmostEqual(two.y_var(), 0.07, delta=0.1)
-            self.assertAlmostEqual(two.covar(), 0.5, delta=0.5)
+            self.assertAlmostEqual(two.y_var(), 0.05, delta=0.1)
+            self.assertAlmostEqual(two.covar(), 0.07, delta=0.1)
             # type 3
             self.assertAlmostEqual(three.count(), generate_count * 3 / 20, delta=generate_count * 0.2)
-            self.assertAlmostEqual(two.covar(), -0.5, delta=0.5)
+            self.assertAlmostEqual(three.covar(), -1.39, delta=1.4)
             # type 4
             self.assertAlmostEqual(four.count(), generate_count * 3 / 20, delta=generate_count * 0.2)
-            self.assertAlmostEqual(two.covar(), 0.5, delta=0.5)
+            self.assertAlmostEqual(four.covar(), 2.22, delta=2.3)
             # type 5/fish
             self.assertAlmostEqual(fish.count(), generate_count * 3 / 20, delta=generate_count * 0.2)
             self.assertAlmostEqual(fish.x_mean(), 8.1, delta=3.0)


### PR DESCRIPTION
`datafaker configure-generators --spec spec.csv` allows multiple generators per line (starting on the third column and continuing to the right); the first one that datafaker accepts is chosen.
