### PR TITLE
SELECT command with syntax error causes stack dump

### DIFF
--- a/datafaker/interactive/base.py
+++ b/datafaker/interactive/base.py
@@ -361,7 +361,7 @@ class DbCmd(ABC, cmd.Cmd):
             try:
                 result = connection.execute(sqlalchemy.text(query))
             except sqlalchemy.exc.DatabaseError as exc:
-                self.print(self.ERROR_FAILED_SQL, exc, query)
+                self.print(self.ERROR_FAILED_SQL, exc=exc, query=query)
                 return
             row_count = result.rowcount
             self.print(self.ROW_COUNT_MSG, row_count)
@@ -403,7 +403,7 @@ class DbCmd(ABC, cmd.Cmd):
             try:
                 result = connection.execute(query)
             except sqlalchemy.exc.SQLAlchemyError as exc:
-                self.print(self.ERROR_FAILED_SQL, exc, query)
+                self.print(self.ERROR_FAILED_SQL, exc=exc, query=query)
                 return
             self.print_table(list(result.keys()), result.fetchmany(max_peek_rows))
 

--- a/tests/test_interactive_table.py
+++ b/tests/test_interactive_table.py
@@ -1,5 +1,6 @@
 """ Tests for the configure-tables command. """
-from collections.abc import MutableMapping
+import re
+from collections.abc import MutableMapping, Sized
 from typing import Any
 
 from sqlalchemy import select
@@ -452,7 +453,7 @@ class ConfigureTablesInstrumentsTests(ConfigureTablesTests):
 
 
 class TrickyTests(ConfigureTablesTests):
-    """Testing configure-tables with the instrument.sql database."""
+    """Testing configure-tables with arguments that could cause SQL errors."""
 
     dump_file_path = "tricky.sql"
     database_name = "tricky"
@@ -536,6 +537,21 @@ class TrickyTests(ConfigureTablesTests):
                 "Failed to display", "/".join(m for (m, _a, _kw) in tc.messages)
             )
 
+    def assert_message_correctly_formatted(
+        self, m: str, a: Sized, kw: dict[str, Any]
+    ) -> None:
+        """
+        Assert that the ``{...}`` interpolations in ``m`` match the arguments given.
+
+        :param m: The message.
+        :param a: List of positional arguments.
+        :param kw: Dict of keyword arguments.
+        """
+        interpolations = set(re.findall(r"\{([A-Za-z0-9_]+)\}", m))
+        positions = set(range(len(a)))
+        keywords = set(kw.keys())
+        self.assertSetEqual(interpolations, positions | keywords)
+
     def test_sql_error_does_not_throw_exception(self) -> None:
         """
         Select with a SQL error.
@@ -543,4 +559,6 @@ class TrickyTests(ConfigureTablesTests):
         with self._get_cmd({}) as tc:
             tc.reset()
             tc.do_select("+++")
-            self.assertIn("SQL query", "/".join(m for (m, a, kw) in tc.messages))
+            self.assertIn("SQL query", "/".join(m for (m, _a, _kw) in tc.messages))
+            for m, a, kw in tc.messages:
+                self.assert_message_correctly_formatted(m, a, kw)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -173,9 +173,8 @@ class TestDuckDb(TestDatabaseBase):
 
     @classmethod
     def skip(cls) -> str | None:
-        if shutil.which("duckdb"):
-            return None
-        return "need to find 'duckdb': install DuckDB to enable"
+        """Return None because DuckDB always works."""
+        return None
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize TestDuckDb"""


### PR DESCRIPTION
Fixed #78
Even though there's a test for this!
The problem is that the rendering of the error message crashes!
The test has been updated so that it checks that error message arguments are passed correctly, and the error message arguments have been changed to be passed correctly.