### PR TITLE
Make psycopg2 import optional in db_utils

### DIFF
--- a/datafaker/db_utils.py
+++ b/datafaker/db_utils.py
@@ -10,8 +10,16 @@ from typing import Any, Iterable, Optional, Union
 import sqlalchemy.dialects
 import yaml
 
-# pylint: disable=no-name-in-module
-from psycopg2.errors import UndefinedObject  # ty: ignore[unresolved-import]
+try:
+    # pylint: disable=no-name-in-module
+    from psycopg2.errors import UndefinedObject  # ty: ignore[unresolved-import]
+except ImportError:
+    # psycopg2 is only installed with the "postgres" extra; this error can
+    # only be raised by the psycopg2 driver, so it never matches otherwise.
+    class UndefinedObject:  # type: ignore[no-redef]
+        """Placeholder when psycopg2 is not installed."""
+
+
 from sqlalchemy import Connection, Engine, ForeignKey, create_engine, event, select
 from sqlalchemy.engine.interfaces import DBAPIConnection
 from sqlalchemy.exc import (

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -34,8 +34,8 @@ from datafaker.settings import SettingsError
 from tests.utils import (
     DatafakerTestCase,
     GeneratesDBTestCase,
-    RequiresDBTestCase,
     MsSqlTestDb,
+    RequiresDBTestCase,
 )
 
 

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -11,7 +11,7 @@ from typer.testing import CliRunner
 
 from datafaker.dump import CsvTableWriter, get_parquet_table_writer
 from datafaker.main import app
-from tests.utils import DatafakerTestCase, RequiresDBTestCase, DuckTestDb, MsSqlTestDb
+from tests.utils import DatafakerTestCase, DuckTestDb, MsSqlTestDb, RequiresDBTestCase
 
 
 class DumpTests(RequiresDBTestCase):

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -10,7 +10,7 @@ from sqlalchemy import create_engine, inspect
 from typer.testing import CliRunner, Result
 
 from datafaker.main import app
-from tests.utils import RequiresDBTestCase, DuckTestDb, MsSqlTestDb
+from tests.utils import DuckTestDb, MsSqlTestDb, RequiresDBTestCase
 
 # pylint: disable=subprocess-run-check
 

--- a/tests/test_interactive_generators.py
+++ b/tests/test_interactive_generators.py
@@ -15,11 +15,11 @@ from datafaker.interactive.base import DbCmd
 from datafaker.interactive.generators import GeneratorCmd
 from datafaker.proposers.choice import ChoiceProposerFactory
 from tests.utils import (
+    DuckTestDb,
     GeneratesDBTestCase,
+    MsSqlTestDb,
     RequiresDBTestCase,
     TestDbCmdMixin,
-    DuckTestDb,
-    MsSqlTestDb,
 )
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -12,8 +12,8 @@ from datafaker.main import app
 from datafaker.settings import Settings, SettingsError
 from tests.utils import (
     DatafakerTestCase,
-    GeneratesDBTestCase,
     DuckTestDb,
+    GeneratesDBTestCase,
     MsSqlTestDb,
     get_test_settings,
 )


### PR DESCRIPTION
## Summary
- `datafaker/db_utils.py` imported `psycopg2.errors.UndefinedObject` unconditionally at module level, but `psycopg2-binary` is only installed via the optional `postgres` extra (see `pyproject.toml`).
- Any environment that installs only the `mssql` extra (not `postgres`) fails to import `datafaker` at all, which previously broke the standalone `tests-mssql.yml` workflow before it was replaced.
- Fix: import `UndefinedObject` inside a `try/except ImportError`, falling back to an empty placeholder class. `UndefinedObject` is psycopg2-specific and can only ever match errors raised by the psycopg2 driver, so the `isinstance` check at the one call site safely evaluates to `False` when psycopg2 isn't installed -- no behavior change when it is.

(Note: this PR originally also fixed a gpg/`/dev/tty` failure in `tests-mssql.yml`, but that workflow was removed upstream in favor of running MSSQL tests directly in `tests.yml`, which sidesteps the issue. Rebased to drop that now-moot commit.)

## Test plan
- [x] Verified locally that `datafaker.db_utils` imports successfully with `psycopg2` mocked as absent, and that the `isinstance` check safely returns `False`
- [x] CI passes on this branch

Generated with Claude Code