### PR TITLE
Update documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       # need this to be able to run the workflow until it has been merged into main
-      - overview_documentation
+      - yhong123/131-update_documentation
   workflow_dispatch:
 env:
   PYTHON_VERSION: "3.12"

--- a/.gitignore
+++ b/.gitignore
@@ -155,3 +155,5 @@ docs/temp/*
 *_stories.py
 
 /examples/opiates/*
+/examples/pagila/*
+

--- a/.gitignore
+++ b/.gitignore
@@ -156,4 +156,3 @@ docs/temp/*
 
 /examples/opiates/*
 /examples/pagila/*
-

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Synthetic data for SQL databases
 Welcome to `datafaker`, based on the Alan Turing Institute's [sqlsynthgen](https://github.com/alan-turing-institute/sqlsynthgen).
 
 For now, please read the [source documentation](docs/source/).
+The documentation is also available on <https://safehr-data.github.io/datafaker/>.
 
 ## Development
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,11 @@
+# Requirements to build the datafaker docs
+# Install with: python3 -m pip install -r requirements.txt
+
+sphinx==9.1.0
+sphinx-rtd-theme==3.1.0
+sphinxcontrib-mermaid==2.1.0
+
+# Optional: runtime dependencies referenced by autodoc. Uncomment if you want autodoc to import modules
+# jsonschema>=4.0
+# pandas>=2.0
+# numpy>=1.27

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,10 +3,10 @@
 Datafaker
 ---------
 
-**Datafaker** is a package for generating synthetic versions of relational and tabular datasets. 
-It can work with relational databases as well as Parquet files through DuckDB integration. 
+**Datafaker** is a package for generating synthetic versions of relational and tabular datasets.
+It can work with relational databases as well as Parquet files through DuckDB integration.
 
-If you are new to Datafaker, we recommend following the documentation in order: start with the :ref:`Installation <page-installation>` guide and learn the basic commands that Datafaker uses from the :ref:`Command-Line Interface (CLI) Guide <page-quickstart>`. 
+If you are new to Datafaker, we recommend following the documentation in order: start with the :ref:`Installation <page-installation>` guide and learn the basic commands that Datafaker uses from the :ref:`Command-Line Interface (CLI) Guide <page-quickstart>`.
 Then, work through the :ref:`Tutorials <page-introduction>` before exploring the example use cases and reference documentation.
 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,37 +1,49 @@
 .. _page-index:
 
-datafaker
----------------------------
+Datafaker
+---------
 
-**datafaker** is a package for making copies of relational databases and populating them with random data.
+**Datafaker** is a package for generating synthetic versions of relational and tabular datasets. 
+It can work with relational databases as well as Parquet files through DuckDB integration. 
 
-If you are new to datafaker, we recommend going through the pages of this documentation roughly in order:
-After :ref:`installing <page-installation>` datafaker and learning the basic commands that it uses from the :ref:`quick start guide <page-quickstart>`, the :ref:`introductory tutorial <page-introduction>` will walk you through a relatively simple use case in detail.
-You can then look at one of our other two example use cases, one for :ref:`financial data <page-example-loan-data>` and one for :ref:`health data <page-example-health-data>`.
-The latter also goes through some more advanced features of datafaker and how to use them, that are relevant beyond health data use cases.
+If you are new to Datafaker, we recommend following the documentation in order: start with the :ref:`Installation <page-installation>` guide and learn the basic commands that Datafaker uses from the :ref:`Command-Line Interface (CLI) Guide <page-quickstart>`. 
+Then, work through the :ref:`Tutorials <page-introduction>` before exploring the example use cases and reference documentation.
+
 
 .. note::
 
-   This project will be under active development from Jan - Oct 2023
+   New features are regularly added. See the GitHub repository for the latest updates.
 
 Contents:
 ---------
 
 .. toctree::
-   :glob:
    :maxdepth: 2
+   :caption: Getting Started
 
-   overview
+   Overview <overview>
    installation
    docker
-   quickstart
-   introduction
+   Command-Line Interface (CLI) Guide <quickstart>
+   Tutorial: Generate Synthetic Data from PostgreSQL <introduction>
+   Tutorial: Generate Synthetic Data from CSV and Parquet <tutorial_parquet>
+
+.. toctree::
+   :glob:
+   :maxdepth: 1
+   :caption: Advanced
+
    orm
-   loan_data
-   health_data
    configuration
-   custom_generators
+   health_data
+   Custom Generators <custom_generators>
    api
+
+.. toctree::
+   :glob:
+   :maxdepth: 1
+   :caption: Reference
+
    faq
    glossary
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -73,8 +73,9 @@ Install and check the MS SQL tools:
    $ odbcinst -q -d
    [ODBC Driver 18 for SQL Server]
 
+
 Use in a docker container
-=========================
+-------------------------
 
 It can also be used directly within a Docker container by downloading image ``timband/datafaker``.
 See the :ref:`quickstart guide <page-quickstart>` for more information.

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -1,7 +1,7 @@
 .. _page-introduction:
 
-Introductory Tutorial
-==============================
+Tutorial: Generate Synthetic Data from PostgreSQL
+================================================================
 
 Let us begin with a simple movie rental database called `Pagila <https://github.com/devrimgunduz/pagila>`_. Follow the instructions there to create a PostgreSQL database if you want to follow this tutorial along.
 Pagila is already fake data, but we shall pretend that it has sensitive data in it, and we are attempting to keep this data secure.

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -1,7 +1,7 @@
 .. _page-quickstart:
 
-Quick Start
-===========
+Command-Line Interface (CLI) Guide
+===============================================
 
 Overview
 --------

--- a/docs/source/tutorial_parquet.rst
+++ b/docs/source/tutorial_parquet.rst
@@ -374,6 +374,3 @@ Troubleshooting
   For example, if ``DST_DSN`` is set to ``duckdb:////path/to/file.db`` then ``DST_SCHEMA`` could be set to ``file.myschema``.
 
 .. _duckdb bug: https://github.com/duckdb/duckdb/issues/20530
-
-
-

--- a/docs/source/tutorial_parquet.rst
+++ b/docs/source/tutorial_parquet.rst
@@ -1,0 +1,379 @@
+Tutorial: Generate Synthetic Data from CSV and Parquet Files
+==============================================================
+
+This tutorial demonstrates how to use Datafaker with CSV and Parquet datasets
+through DuckDB. By the end of the tutorial, you will be able to generate
+synthetic data from existing files and export the results in CSV or Parquet
+format.
+
+Overview
+^^^^^^^^
+
+Datafaker can work directly with CSV and Parquet files through DuckDB.
+You do not need to import these files into a separate database before
+generating synthetic data.
+
+The workflow is:
+
+1. Configure source and destination DSNs.
+2. Generate an ``orm.yaml`` file.
+3. Review and refine the schema definition.
+4. Generate synthetic data.
+5. Export the results.
+
+Using a DuckDB Database
+^^^^^^^^^^^^^^^^^^^^^^^
+
+If your source data already resides in a DuckDB database, configure the
+source and destination databases using DSNs.
+
+macOS / Linux:
+
+.. code-block:: shell
+
+   export SRC_DSN=duckdb:////path/to/source.db
+   export DST_DSN=duckdb:////path/to/fake.db
+
+Windows Command Prompt:
+
+.. code-block:: shell
+
+   set SRC_DSN=duckdb:///C:/path/to/source.db
+   set DST_DSN=duckdb:///C:/path/to/fake.db
+
+Windows PowerShell:
+
+.. code-block:: shell
+
+   $env:SRC_DSN='duckdb:///C:/path/to/source.db'
+   $env:DST_DSN='duckdb:///C:/path/to/fake.db'
+
+Create the destination schema:
+
+.. code-block:: shell
+
+   datafaker create-tables
+
+Using CSV and Parquet Files as Input
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If your source data consists of CSV or Parquet files, use an in-memory
+DuckDB instance as the source database.
+
+macOS / Linux:
+
+.. code-block:: shell
+
+   export SRC_DSN=duckdb:///:memory:
+   export DST_DSN=duckdb:///./fake.db
+
+Windows:
+
+.. code-block:: shell
+
+   set SRC_DSN=duckdb:///:memory:
+   set DST_DSN=duckdb:///./fake.db
+
+Example directory structure:
+
+.. code-block:: text
+
+   input_data/
+   ├── artist.parquet
+   └── artwork.parquet
+
+Building the ORM Configuration
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Datafaker needs an ``orm.yaml`` file describing tables,
+columns, keys, and relationships.
+
+Generating an Initial ORM
+"""""""""""""""""""""""""
+
+Generate a first draft of the ORM from your Parquet files:
+
+.. code-block:: shell
+
+   datafaker make-tables --parquet-dir ./input_data
+
+This creates:
+
+.. code-block:: text
+
+   orm.yaml
+
+This generates an initial ``orm.yaml`` file based on the Parquet files found in
+the specified directory. The generated ``orm.yaml`` provides a useful starting point, but it may not
+be entirely correct. Always review warnings carefully and verify primary keys,
+foreign keys, column types, and nullability before proceeding.
+
+Suppose your input directory contains two files:
+
+* ``artist.parquet``
+* ``artwork.parquet``
+
+The ``orm.yaml`` file describes the tables, columns, data types, primary keys,
+foreign keys, and nullability rules used by Datafaker.
+
+For example:
+
+.. code-block:: yaml
+
+   tables:
+      artist.parquet:  # this is the name of the parquet file
+         columns:
+            artist_id:
+               type: INTEGER
+               primary: true  # mark artist_id as the primary key
+               nullable: false  # columns are nullable by default, so set this if not.
+            name:
+               type: TEXT
+            gender:
+               type: TEXT
+            nationality:
+               type: TEXT
+            birth_date:
+               type: DATE
+            end_date:
+               type: DATE
+      artwork.parquet:  # The other parquet file
+         columns:
+            artwork_id:
+               type: INTEGER
+               primary: true
+               nullable: false
+            artist_id:
+               foreign_keys:
+               - artist.parquet.artist_id  # Maps to the artist_id column of the artist.parquet file
+            name:
+               type: TEXT
+            date:
+               type: DATE
+            medium:
+               type: TEXT
+
+Reviewing Primary Keys
+""""""""""""""""""""""
+
+Suppose ``make-tables`` produces:
+
+.. code-block:: text
+
+   WARNING: No likely primary keys found for table artwork.parquet
+
+Update the ORM manually:
+
+.. code-block:: yaml
+
+   artwork.parquet:
+     columns:
+       object_id:
+         type: INTEGER
+         primary: true
+         nullable: false
+
+Reviewing Foreign Keys
+""""""""""""""""""""""
+
+Verify all table relationships.
+
+For example:
+
+.. code-block:: yaml
+
+   artist_artwork.parquet:
+     columns:
+       artist_id:
+         foreign_keys:
+         - artist.parquet.artist_id
+
+       object_id:
+         foreign_keys:
+         - artwork.parquet.object_id
+
+Reviewing Data Types and Nullability
+""""""""""""""""""""""""""""""""""""
+
+Check inferred column types:
+
+.. code-block:: yaml
+
+   birth_date:
+     type: DATE
+     nullable: true
+
+   artwork_id:
+     type: INTEGER
+     nullable: false
+
+Ensure these definitions match the source data.
+
+Generating Synthetic Data
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Once the ORM has been reviewed, generate the Datafaker configuration
+and source statistics:
+
+.. code-block:: shell
+
+   datafaker configure-tables
+   datafaker configure-generators
+   datafaker configure-missingness
+   datafaker make-stats
+
+This creates:
+
+.. code-block:: text
+
+   orm.yaml
+   config.yaml
+   src-stats.yaml
+
+Create the destination schema:
+
+.. code-block:: shell
+
+   datafaker create-tables
+
+Generate synthetic data:
+
+.. code-block:: shell
+
+   datafaker create-data --num-passes 100
+
+Exporting Synthetic Data
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+After generation, the synthetic data resides in the destination DuckDB
+database.
+
+Exporting to CSV
+""""""""""""""""
+
+Create a CSV output directory:
+
+.. code-block:: shell
+
+   mkdir fake_csv
+
+Export all tables:
+
+.. code-block:: shell
+
+   datafaker dump-data --output ./fake_csv/
+
+Result:
+
+.. code-block:: text
+
+   fake_csv/
+   ├── artist.csv
+   └── artwork.csv
+
+Exporting to Parquet
+""""""""""""""""""""
+
+Create a Parquet output directory:
+
+.. code-block:: shell
+
+   mkdir fake_parquet
+
+Export all tables:
+
+.. code-block:: shell
+
+   datafaker dump-data --parquet --output ./fake_parquet/
+
+Result:
+
+.. code-block:: text
+
+   fake_parquet/
+   ├── artist.parquet
+   └── artwork.parquet
+
+End-to-End Example
+^^^^^^^^^^^^^^^^^^
+
+Assume you have a directory containing sensitive Parquet files:
+
+.. code-block:: text
+
+   input_parquet/
+   ├── artist.parquet
+   └── artwork.parquet
+
+Configure DSNs:
+
+.. code-block:: shell
+
+   export SRC_DSN=duckdb:///:memory:
+   export DST_DSN=duckdb:///./fake.db
+
+Generate the ORM:
+
+.. code-block:: shell
+
+   datafaker make-tables --parquet-dir ./input_parquet
+
+Review and update ``orm.yaml`` as necessary.
+
+Generate configuration:
+
+.. code-block:: shell
+
+   datafaker configure-tables
+   datafaker configure-generators
+   datafaker configure-missingness
+   datafaker make-stats
+
+Create schema and generate data:
+
+.. code-block:: shell
+
+   datafaker create-tables
+   datafaker create-data --num-passes 100
+
+Export synthetic Parquet files:
+
+.. code-block:: shell
+
+   mkdir fake
+   datafaker dump-data --parquet --output ./fake
+
+Quick Recipe: Parquet to CSV
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For a minimal end-to-end workflow:
+
+.. code-block:: shell
+
+   export SRC_DSN=duckdb:///:memory:
+   export DST_DSN=duckdb:///./fake.db
+
+   datafaker make-tables --parquet-dir ./input_parquet
+
+   datafaker create-tables
+   datafaker create-data --num-passes 1
+
+   mkdir fake_csv
+
+   datafaker dump-data --output ./fake_csv/
+
+Troubleshooting
+^^^^^^^^^^^^^^^
+
+* If you see a command not found error when running ``datafaker``, run the command using Poetry instead: ``poetry run datafaker``
+* If ``make-tables`` logs warnings like "Could not determine type of column ...",
+  inspect and fix the Parquet schema or edit ``orm.yaml`` (nested/struct or
+  mixed-type columns often need flattening or manual typing).
+* Setting ``SRC_SCHEMA`` or ``DST_SCHEMA`` can expose a `DuckDB bug`_ that produces very confusing error messages.
+  If you must use a schema, you must prefix it with the basename of the database file.
+  For example, if ``DST_DSN`` is set to ``duckdb:////path/to/file.db`` then ``DST_SCHEMA`` could be set to ``file.myschema``.
+
+.. _duckdb bug: https://github.com/duckdb/duckdb/issues/20530
+
+
+


### PR DESCRIPTION
Resolved #131

**Summary**
This PR updates and reorganises the Datafaker documentation to improve clarity, navigation, and onboarding for users. In particular, it adds a new tutorial covering the workflow required by Paul and Shipra for generating synthetic Camino data from Parquet files.

**Changes**

- Added "Tutorial: Generate Synthetic Data from CSV and Parquet" (`tutorial_parquet.rst`), which serves as the primary guide for Paul and Shipra's use case.
   - The existing DuckDB documentation (`duckdb.rst`) has been retained for the time being and can be removed later if Tim agrees that `tutorial_parquet.rst` provides sufficient coverage.
- Restructured the documentation into two main sections: "Getting Started" and "Advanced".
- Updated `index.rst` to:
   - Refresh the introduction.
   - Remove outdated notes.
   - Revise the table of contents to reflect the new documentation structure.
- Renamed "Quick Start" to "Command-line Interface (CLI) Guide" to better represent the scope and content of `quickstart.rst`.
   - This change can be reverted if the original title is preferred.
- Renamed "Introductory Tutorial" to "Tutorial: Generate Synthetic Data from PostgreSQL" to improve clarity and maintain consistency with the naming convention used for other tutorials.
- Corrected a minor formatting issue in `installation.rst`.
- Removed "Example: Loan Data" (`loan_data.rst`) from `index.rst` because the example describes Turing's SqlSynthGen rather than Datafaker.
   - The file itself remains in the repository and can be removed later if Tim agrees.
- Added `requirements.txt` file for building the Sphinx documentation.
   - The file specifies the versions of Sphinx and the Mermaid extension required to build the documentation.
   - This simplifies the process of creating a virtual environment and installing the necessary dependencies before running poetry run make html in the docs directory.
- Updated `/datafaker/README.md` to include a link to the documentation GitHub Pages site.

**Future Work**
The "Advanced" section would benefit from additional review and reorganisation. Further documentation improvements can be addressed in a subsequent documentation-focused PR.

